### PR TITLE
fixing config read

### DIFF
--- a/zsnap/config.py
+++ b/zsnap/config.py
@@ -375,6 +375,7 @@ class Config(object):
                 config.read_dict(default_dict)
             config.read_file(file_)
             if dirname:
+                file_list = []
                 for root, dirs, files in os.walk(dirname):
                     file_list = [os.path.join(root, name) for name in files]
                 config.read(file_list)


### PR DESCRIPTION
Error:

```
[root@testzsnapd]# ./zsnapd-cfgtest
Traceback (most recent call last):
  File "./zsnapd-cfgtest", line 32, in <module>
    process.main()
  File "/usr/local/lib/python3.6/site-packages/magcode/core/process.py", line 419, in main
    self.main_process()
  File "/usr/share/zsnapd/zsnap/zsnapd_cfgtest.py", line 57, in main_process
    ds_settings = Config.read_ds_config()
  File "/usr/share/zsnapd/zsnap/config.py", line 409, in read_ds_config
    template_config = read_config(template_filename, template_dirname)
  File "/usr/share/zsnapd/zsnap/config.py", line 380, in read_config
    config.read(file_list)
UnboundLocalError: local variable 'file_list' referenced before assignment
```
If template.d extensions are not used, then when loading the configuration, an uninitialled variable is accessed.

